### PR TITLE
Fixed leaks in child_processes

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -107,7 +107,7 @@ char	*get_cmd_path(t_mini *shell, t_cmd *cmds, char *cmd);
 //execution/pipes.c
 void	close_unused_fds(t_mini *shell, int i);
 void	close_fds_and_pipes(t_mini *shell, int i);
-int		fork_and_execute(t_mini *shell, t_cmd *cmd);
+int		fork_and_execute(t_mini *shell, t_cmd *cmd, t_cmd *head);
 int		init_pipeline(t_mini *shell);
 
 //redirect/file_handler.c

--- a/srcs/execution/exec_utils.c
+++ b/srcs/execution/exec_utils.c
@@ -99,7 +99,7 @@ bool	is_dir(char *path)
  * accessibility and validity. Upon encountering any error, calls
  * `error_cmd()` with the corresponding error message and exit code.
  * */
-void	check_access(t_mini *shell, t_cmd *cmds, char *cmd)
+void	check_access(t_mini *shell, t_cmd *cmds, char *cmd) // here cmds is starting from head
 {
 	if (!cmd)
 		error_cmd(shell, cmds, cmd, "command not found", 127);

--- a/srcs/lexer/valid_input.c
+++ b/srcs/lexer/valid_input.c
@@ -87,6 +87,17 @@ int	valid_pipes(t_mini *shell, const char *input)
 	return (TRUE);
 }
 
+// int	str_only_quotes_or_wp(const char *str) // this is probably unnecessary
+// {
+// 	while (*str)
+// 	{
+// 		if (*str != 32 && (*str < 9 || *str > 13) && *str != '"' && *str != '\'')
+// 			return (FALSE);
+// 		str++;
+// 	}
+// 	return (TRUE);
+// }
+
 int	closed_pipes(t_mini *shell, const char *input)
 {
 	int	i;
@@ -94,6 +105,10 @@ int	closed_pipes(t_mini *shell, const char *input)
 
 	i = 0;
 	open = 0;
+	while (input[i] && char_is_whitespace(input[i]))
+		i++;
+	if (input[i] == '|')
+		return (error_syntax(shell, "|"), FALSE);
 	while (input[i])
 	{
 		if (input[i] == '\'' || input[i] == '"')

--- a/srcs/utils/cleanup.c
+++ b/srcs/utils/cleanup.c
@@ -63,6 +63,7 @@ void	cleanup_success(t_mini *shell, t_cmd *cmd)
 	}
 	free_pipes(shell, j);
 	cleanup(shell, cmd);
+	shell->cmd_count = 0;
 }
 
 void	cleanup(t_mini *shell, t_cmd *cmd)


### PR DESCRIPTION
Fixed leaks in child_processes, added cmd lists head to some function calls and to cleanup commands so the whole command list is iterated in the cleaning processes. There are comments to clarify the modifications. Also made additional check for pipe syntax error.