### PR TITLE
Fixed logic for infile 's redirection handling

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -81,6 +81,7 @@ void	error_file(t_mini *shell, char *file, char *error_str, int ex);
 int		execute(t_mini *shell, t_cmd *cmd);
 
 //execution/dup_close.c
+int		configure_fds_child(t_mini *shell, t_cmd *cmd);
 int		configure_fds(t_mini *shell, t_cmd *cmd);
 int		dup_input(t_mini *shell, t_cmd *cmd, int i);
 int		dup_output(t_mini *shell, t_cmd *cmd, int i);
@@ -117,7 +118,9 @@ int		open_append_file(t_mini *shell, char *outfile);
 int		handle_heredoc(t_mini *shell, char *delimiter);
 
 //redirect/redirect.c
+void	close_extra_fd(int fd);
 int		redirect_fd(int src_fd, int dest_fd);
+int		handle_redirection_child(t_mini *shell, t_cmd *cmd);
 int		handle_redirection(t_mini *shell, t_cmd *cmd);
 int		resolve_input(t_mini *shell, t_cmd *cmd, t_token *token);
 int		resolve_output(t_mini *shell, t_cmd *cmd, t_token *token);

--- a/includes/structs.h
+++ b/includes/structs.h
@@ -125,6 +125,7 @@ typedef struct s_cmd
 	int				output_fd;
 	int				saved_stdin;
 	int				saved_stdout;
+	int				heredoc_i;
 	int				cmd_i;
 	struct s_cmd	*next;
 }	t_cmd;

--- a/srcs/execution/dup_close.c
+++ b/srcs/execution/dup_close.c
@@ -1,7 +1,7 @@
 #include "minishell.h"
 
 /**
- * configure_fds - Resolves file descriptors for input and output redirection.
+ * configure_fds - Resolves file descriptors for input and output redirection in the parent process.
  *
  * @shell: Pointer to the shell structure.
  * @cmd: Pointer to the command structure.
@@ -21,6 +21,34 @@ int	configure_fds(t_mini *shell, t_cmd *cmd)
 		cmd->input_fd = STDIN_FILENO;
 	if (cmd->output_fd == -1)
 		cmd->output_fd = STDOUT_FILENO;
+	return (TRUE);
+}
+
+/**
+ * configure_fds_child - Resolves file descriptors for input and output redirection in the child process.
+ *
+ * @shell: Pointer to the shell structure.
+ * @cmd: Pointer to the command structure.
+ *
+ * Processes input and output redirections specified in the command using 
+ * `handle_redirection()`. If no redirection is specified, sets the input file 
+ * descriptor to `STDIN_FILENO` and the output file descriptor to 
+ * `STDOUT_FILENO`.
+ *
+ * Returns TRUE on success or FALSE if redirection processing fails.
+ * */
+int	configure_fds_child(t_mini *shell, t_cmd *cmd)
+{
+	// printf("input_fd: %d\n", cmd->input_fd);
+	// printf("output_fd: %d\n", cmd->output_fd);
+	if (!handle_redirection_child(shell, cmd))
+		return (FALSE);
+	if (cmd->input_fd == -1)
+		cmd->input_fd = STDIN_FILENO;
+	if (cmd->output_fd == -1)
+		cmd->output_fd = STDOUT_FILENO;
+	// printf("input_fd after: %d\n", cmd->input_fd);
+	// printf("output_fd after: %d\n", cmd->output_fd);
 	return (TRUE);
 }
 

--- a/srcs/execution/exec_child.c
+++ b/srcs/execution/exec_child.c
@@ -106,8 +106,10 @@ int	fork_and_execute(t_mini *shell, t_cmd *cmd, t_cmd *head) // added head (for 
 static int	resolve_heredoc(t_mini *shell, t_cmd *cmd)
 {
 	t_token	*token;
+	int		i;
 
 	token = cmd->tokens;
+	i = 0;
 	while (token)
 	{
 		if (token->type == HEREDOC)
@@ -120,9 +122,10 @@ static int	resolve_heredoc(t_mini *shell, t_cmd *cmd)
 			cmd->input_fd = handle_heredoc(shell, token->next->value);
 			if (cmd->input_fd == -1)
 				return (FALSE); // pipe_error
-			cmd->heredoc_i++;
+			cmd->heredoc_i = i;
 		}
 		token = token->next;
+		i++;
 	}
 	return (TRUE);
 }

--- a/srcs/execution/exec_child.c
+++ b/srcs/execution/exec_child.c
@@ -37,7 +37,9 @@ static void	exec_forked_cmd(t_mini *shell, t_cmd *cmd, t_cmd *head) // added hea
 {
 	char	*cmd_path;
 
+	// printf("cmd: %s\n", cmd->cmds[0]);
 	cmd_path = get_cmd_path(shell, cmd, cmd->cmds[0]);
+	// printf("cmd path: %s\n", cmd_path);
 	if (!cmd_path)
 		check_access(shell, head, cmd->cmds[0]); // modified cmd -> head for potential cleanup
 	else
@@ -84,7 +86,7 @@ int	fork_and_execute(t_mini *shell, t_cmd *cmd, t_cmd *head) // added head (for 
 	{
 		signal_child();
 		close_unused_fds(shell, cmd->cmd_i);
-		if (!configure_fds(shell, cmd))
+		if (!configure_fds_child(shell, cmd))
 		{
 			cleanup_failure(shell, head, shell->exit_code); // modified cmd -> head
 			return (FALSE);
@@ -97,6 +99,30 @@ int	fork_and_execute(t_mini *shell, t_cmd *cmd, t_cmd *head) // added head (for 
 			exec_forked_builtin(shell, cmd, head, is_builtin); // added head to the function call
 		else
 			exec_forked_cmd(shell, cmd, head); // added head to the function call
+	}
+	return (TRUE);
+}
+
+static int	resolve_heredoc(t_mini *shell, t_cmd *cmd)
+{
+	t_token	*token;
+
+	token = cmd->tokens;
+	while (token)
+	{
+		if (token->type == HEREDOC)
+		{
+			if (cmd->input_fd != -1)
+			{
+				close(cmd->input_fd);
+				cmd->input_fd = -1;
+			}
+			cmd->input_fd = handle_heredoc(shell, token->next->value);
+			if (cmd->input_fd == -1)
+				return (FALSE); // pipe_error
+			cmd->heredoc_i++;
+		}
+		token = token->next;
 	}
 	return (TRUE);
 }
@@ -119,30 +145,6 @@ int	fork_and_execute(t_mini *shell, t_cmd *cmd, t_cmd *head) // added head (for 
  * Returns TRUE on success or FALSE if an error occurs during initialization, 
  * execution, or cleanup.
  */
-
-int	resolve_heredoc(t_mini *shell, t_cmd *cmd)
-{
-	t_token	*token;
-
-	token = cmd->tokens;
-	while (token)
-	{
-		if (token->type == HEREDOC)
-		{
-			if (cmd->input_fd != -1)
-			{
-				close(cmd->input_fd);
-				cmd->input_fd = -1;
-			}
-			cmd->input_fd = handle_heredoc(shell, token->next->value);
-			if (cmd->input_fd == -1)
-				return (FALSE); // pipe_error
-		}
-		token = token->next;
-		cmd->heredoc_i++;
-	}
-}
-
 int	exec_child(t_mini *shell, t_cmd *cmd)
 {
 	t_cmd	*curr;
@@ -152,10 +154,11 @@ int	exec_child(t_mini *shell, t_cmd *cmd)
 	curr = cmd;
 	while (curr)
 	{
-		// if (!resolve_heredoc(shell, curr))
-		// 	return (FALSE); // cleanup && return
+		if (!resolve_heredoc(shell, curr))
+			return (FALSE); // cleanup && return
 		if (fork_and_execute(shell, curr, cmd) == -1)
 			return (FALSE); // cleanup && return
+		close_extra_fd(curr->input_fd);
 		close_fds_and_pipes(shell, curr->cmd_i);
 		curr = curr->next;
 	}

--- a/srcs/execution/exec_path.c
+++ b/srcs/execution/exec_path.c
@@ -84,7 +84,7 @@ char	*get_cmd_path(t_mini *shell, t_cmd *cmds, char *cmd)
 	char	*cmd_path;
 	char	**env_path;
 
-	if (*cmd == '\0')
+	if (!cmd || *cmd == '\0')
 		return (NULL);
 	if (ft_strchr(cmd, '/'))
 	{

--- a/srcs/lexer/expand.c
+++ b/srcs/lexer/expand.c
@@ -174,7 +174,7 @@ char	*expand_input(t_mini *shell, char *input)
 		// printf("i = %d\n", i);
 		if (input[i] == '\'')
 			i += quote_offset(input + i, input[i]);
-		if (input[i] == '$' && input[i + 1] && input[i + 1] != '$')
+		if (input[i] == '$' && input[i + 1] && input[i + 1] != '$' && input[i + 1] != '/')
 		{
 			if (char_is_whitespace(input[i + 1]) || input[i + 1] == '"' || input[i + 1] == '\'')
 				input = replace_segment(input, i, i + 1, NULL);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,25 +3,6 @@
 volatile sig_atomic_t	g_mrworldwide = 0;
 
 //THIS IS FOR LARGE MINISHELL TESTER, REPLACE THIS SETUP_INPUT WITH THE ONE BELOW BEFORE RUNNING THE TESTER
-static char	*setup_input(t_mini *shell)
-{
-	char	*input;
-	char	prompt[1024];
-
-	input = NULL;
-	get_prompt(shell, prompt, sizeof(prompt));
-	if (isatty(fileno(stdin)))
-		input = readline(prompt);
-	else
-	{
-		char	*line;
-		line = get_next_line(fileno(stdin));
-		input = ft_strtrim(line, "\n");
-		free(line);
-	}
-	return (input);
-}
-
 // static char	*setup_input(t_mini *shell)
 // {
 // 	char	*input;
@@ -29,9 +10,28 @@ static char	*setup_input(t_mini *shell)
 
 // 	input = NULL;
 // 	get_prompt(shell, prompt, sizeof(prompt));
-// 	input = readline(prompt);
+// 	if (isatty(fileno(stdin)))
+// 		input = readline(prompt);
+// 	else
+// 	{
+// 		char	*line;
+// 		line = get_next_line(fileno(stdin));
+// 		input = ft_strtrim(line, "\n");
+// 		free(line);
+// 	}
 // 	return (input);
 // }
+
+static char	*setup_input(t_mini *shell)
+{
+	char	*input;
+	char	prompt[1024];
+
+	input = NULL;
+	get_prompt(shell, prompt, sizeof(prompt));
+	input = readline(prompt);
+	return (input);
+}
 
 static void	minishell(t_mini *shell)
 {

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,25 +3,6 @@
 volatile sig_atomic_t	g_mrworldwide = 0;
 
 //THIS IS FOR LARGE MINISHELL TESTER, REPLACE THIS SETUP_INPUT WITH THE ONE BELOW BEFORE RUNNING THE TESTER
-// static char	*setup_input(t_mini *shell)
-// {
-// 	char	*input;
-// 	char	prompt[1024];
-
-// 	input = NULL;
-// 	get_prompt(shell, prompt, sizeof(prompt));
-// 	if (isatty(fileno(stdin)))
-// 		input = readline(prompt);
-// 	else
-// 	{
-// 		char	*line;
-// 		line = get_next_line(fileno(stdin));
-// 		input = ft_strtrim(line, "\n");
-// 		free(line);
-// 	}
-// 	return (input);
-// }
-
 static char	*setup_input(t_mini *shell)
 {
 	char	*input;
@@ -29,9 +10,28 @@ static char	*setup_input(t_mini *shell)
 
 	input = NULL;
 	get_prompt(shell, prompt, sizeof(prompt));
-	input = readline(prompt);
+	if (isatty(fileno(stdin)))
+		input = readline(prompt);
+	else
+	{
+		char	*line;
+		line = get_next_line(fileno(stdin));
+		input = ft_strtrim(line, "\n");
+		free(line);
+	}
 	return (input);
 }
+
+// static char	*setup_input(t_mini *shell)
+// {
+// 	char	*input;
+// 	char	prompt[1024];
+
+// 	input = NULL;
+// 	get_prompt(shell, prompt, sizeof(prompt));
+// 	input = readline(prompt);
+// 	return (input);
+// }
 
 static void	minishell(t_mini *shell)
 {

--- a/srcs/parser/create_command.c
+++ b/srcs/parser/create_command.c
@@ -14,6 +14,7 @@ static t_cmd	*init_cmd(int i)
 	cmd->saved_stdin = -1;
 	cmd->saved_stdout = -1;
 	cmd->cmd_i = i;
+	cmd->heredoc_i = 0;
 	cmd->next = NULL;
 	return (cmd);
 }

--- a/srcs/redirect/file_handler.c
+++ b/srcs/redirect/file_handler.c
@@ -7,6 +7,7 @@ int	open_infile(t_mini *shell, char *infile)
 	int	input_fd;
 
 	input_fd = open(infile, O_RDONLY);
+	// printf("TASSA OLLAAN input fd on avattu %d\n", input_fd);
 	if (input_fd == -1)
 	{
 		if (access(infile, F_OK) == -1)

--- a/srcs/redirect/heredoc.c
+++ b/srcs/redirect/heredoc.c
@@ -114,3 +114,4 @@ int	handle_heredoc(t_mini *shell, char *lim)
 	close(pipe_fd[1]);
 	return (pipe_fd[0]);
 }
+

--- a/srcs/redirect/redirect.c
+++ b/srcs/redirect/redirect.c
@@ -10,7 +10,7 @@
  * If so, it closes the file descriptor to release resources.
  * 
  */
-static void	close_extra_fd(int fd)
+void	close_extra_fd(int fd)
 {
 	if (fd > 2)
 		close(fd);
@@ -173,17 +173,18 @@ int	handle_redirection_child(t_mini *shell, t_cmd *cmd)
 
 	token = cmd->tokens;
 	i = 0;
+	// printf("heredo_i: %d\n", cmd->heredoc_i);
 	while (token)
 	{
 		if (token->type == REDIR_IN && i >= cmd->heredoc_i)
 		{
-			if (!resolve_input(shell, cmd, token))
+			if (!resolve_input_child(shell, cmd, token))
 			{
 				close_extra_fd(cmd->output_fd);
 				return (FALSE);
 			}
 		}
-		else if (i >= cmd->heredoc_i && (token->type == REDIR_OUT || token->type == REDIR_APPEND))
+		else if (token->type == REDIR_OUT || token->type == REDIR_APPEND)
 		{
 			if (!resolve_output(shell, cmd, token))
 			{

--- a/srcs/redirect/redirect.c
+++ b/srcs/redirect/redirect.c
@@ -76,17 +76,30 @@ int	resolve_input(t_mini *shell, t_cmd *cmd, t_token *token)
 	return (TRUE);
 }
 
-int	resolve_input_child(t_mini *shell, t_cmd *cmd, t_token *token)
+int	resolve_input_child(t_mini *shell, t_cmd *cmd, t_token *token, int redir_i)
 {
-	if (cmd->input_fd != -1)
+	int	fd;
+
+	fd = -1;
+	// if (cmd->input_fd != -1)
+	// {
+	// 	close(cmd->input_fd);
+	// 	cmd->input_fd = -1;
+	// }
+	if (token->type == REDIR_IN)
+		fd = open_infile(shell, token->next->value);
+	if (fd == -2)
 	{
 		close(cmd->input_fd);
 		cmd->input_fd = -1;
-	}
-	if (token->type == REDIR_IN)
-		cmd->input_fd = open_infile(shell, token->next->value);
-	if (cmd->input_fd == -2)
 		return (FALSE);
+	}
+	else if (redir_i >= cmd->heredoc_i)
+	{
+		close(cmd->input_fd);
+		cmd->input_fd = -1;
+		cmd->input_fd = fd;
+	}
 	return (TRUE);
 }
 
@@ -176,9 +189,9 @@ int	handle_redirection_child(t_mini *shell, t_cmd *cmd)
 	// printf("heredo_i: %d\n", cmd->heredoc_i);
 	while (token)
 	{
-		if (token->type == REDIR_IN && i >= cmd->heredoc_i)
+		if (token->type == REDIR_IN)
 		{
-			if (!resolve_input_child(shell, cmd, token))
+			if (!resolve_input_child(shell, cmd, token, i))
 			{
 				close_extra_fd(cmd->output_fd);
 				return (FALSE);


### PR DESCRIPTION
Previous logic for heredoc_i (heredoc redirections placement in syntax) comparison with infile's index (infiles placement in syntax) was unfinished and didn't work for all error cases. Now we try to open every file in the syntax regardless of the redirection's position (to check for potential errors), but prioritize and overwrite cmd->input_fd based on the position of the redirection (highest index wins).

Now cases like < nosuchfile.txt cat << EOF > outfile imitate bash properly.