### PR TITLE
Leak fixes and optional minishell-loop in comments

### DIFF
--- a/includes/parser.h
+++ b/includes/parser.h
@@ -65,6 +65,6 @@ char		*create_quoted_arg(char *str, int *i, int len);
 char		**split_by_pipes(const char *input);
 
 //parser/parser.c
-t_cmd		*tokenizer(t_mini *shell, const char *input);
+t_cmd		*tokenizer(t_mini *shell, char *input);
 
 #endif

--- a/srcs/lexer/expand.c
+++ b/srcs/lexer/expand.c
@@ -93,7 +93,7 @@ char	*expand_exit_code(t_mini *shell, char *input, int *i)
 	free(input);
 	if (!new_input)
 		return (NULL);
-	*i += ft_strlen(value);
+	*i += ft_strlen(value) - 1;
 	free(value);
 	return (new_input);
 }

--- a/srcs/lexer/lexer.c
+++ b/srcs/lexer/lexer.c
@@ -33,6 +33,8 @@ int	valid_input(t_mini *shell, char *input)
 
 int	lexer(t_mini *shell, char *line)
 {
+	if (!valid_input(shell, line))
+		return (FALSE);
 	shell->input = expand_input(shell, line);
 	if (!shell->input)
 	{
@@ -40,8 +42,8 @@ int	lexer(t_mini *shell, char *line)
 		shell->abort = 1;
 		return (FALSE);
 	}
-	if (!valid_input(shell, shell->input))
-		return (FALSE);
+	// if (!valid_input(shell, shell->input))
+	// 	return (FALSE);
 	shell->input = add_missing_spaces(shell->input);
 	// debug_print("%s\n", shell->input);
 	if (!shell->input)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -30,6 +30,8 @@ static char	*setup_input(t_mini *shell)
 	input = NULL;
 	get_prompt(shell, prompt, sizeof(prompt));
 	input = readline(prompt);
+	if (input && *input)
+		add_history(input);
 	return (input);
 }
 
@@ -46,7 +48,7 @@ static void	minishell(t_mini *shell)
 			break ;
 		if (*input)
 		{
-			add_history(input); //this could be moved somewhere in parsing/exec functions
+			// add_history(input); //this could be moved somewhere in parsing/exec functions
 			if (!lexer(shell, input))
 			{
 				if (input && *input)
@@ -62,6 +64,32 @@ static void	minishell(t_mini *shell)
 		shell->cmd_count = 0;
 	}
 }
+
+// static void	minishell(t_mini *shell)
+// {
+// 	char	*input;
+// 	t_cmd	*cmds;
+
+// 	while (TRUE)
+// 	{
+// 		//reset_signals();
+// 		input = setup_input(shell);
+// 		if (input == NULL)
+// 			break ;
+// 		if (*input)
+// 		{
+// 			if (lexer(shell, input))
+// 			{
+// 				cmds = tokenizer(shell, shell->input);
+// 				if (cmds)
+// 					execute(shell, cmds);
+// 			}
+// 			else if (input && *input)
+// 				free(input);
+// 		}
+// 		shell->cmd_count = 0;
+// 	}
+// }
 
 int	main(int argc, char **argv, char **env)
 {

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -18,7 +18,7 @@ static void	add_command(t_cmd **head, t_cmd *new_cmd)
 
 /*Splits input by pipes into command chunks.
 Adds cmd chunks to linked list.*/
-t_cmd	*tokenizer(t_mini *shell, const char *input)
+t_cmd	*tokenizer(t_mini *shell, char *input)
 {
 	char	**cmd_array;
 	t_cmd	*cmd;
@@ -28,6 +28,7 @@ t_cmd	*tokenizer(t_mini *shell, const char *input)
 	i = 0;
 	cmd = NULL;
 	cmd_array = split_by_pipes(input);
+	free(input);
 	if (!cmd_array)
 		return (NULL);
 	while (cmd_array[i] != NULL)


### PR DESCRIPTION
Added free(input) to tokenization process and modified lexer:
- syntax validation back to where it first was: right on top before expanding (no unnecessary mallocs made in cases of invalid syntax
- expand exitcode's index incremention changed from *i += ft_strlen(value) to *i += ft_strlen(value) - 1 to avoid invalid read of size