### PR TITLE
Fixed heredoc without command

### DIFF
--- a/libft/ft_free_array.c
+++ b/libft/ft_free_array.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_free_array.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: prynty <prynty@student.hive.fi>            +#+  +:+       +#+        */
+/*   By: sniemela <sniemela@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/07 17:24:45 by prynty            #+#    #+#             */
-/*   Updated: 2024/10/07 17:26:15 by prynty           ###   ########.fr       */
+/*   Updated: 2025/01/14 15:16:38 by sniemela         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,8 @@ void	ft_free_array(char ***str)
 	size_t	i;
 
 	i = 0;
+	if (!*str)
+		return ;
 	if (*str)
 	{
 		while ((*str)[i] != NULL)

--- a/srcs/execution/exec_child.c
+++ b/srcs/execution/exec_child.c
@@ -37,6 +37,8 @@ static void	exec_forked_cmd(t_mini *shell, t_cmd *cmd, t_cmd *head) // added hea
 {
 	char	*cmd_path;
 
+	if (!cmd->cmds || !cmd->cmds[0])
+		cleanup_failure(shell, head, 0);
 	// printf("cmd: %s\n", cmd->cmds[0]);
 	cmd_path = get_cmd_path(shell, cmd, cmd->cmds[0]);
 	// printf("cmd path: %s\n", cmd_path);

--- a/srcs/lexer/expand.c
+++ b/srcs/lexer/expand.c
@@ -58,26 +58,31 @@ char	*expand_variable(t_mini *shell, char *input, int *i)
 	end = *i + 1;
 	while (input[end] && !char_is_whitespace(input[end]) && input[end] != '$'
 		&& input[end] != '/' && input[end] != '"' && input[end] != '\'')
-	{
-		// printf("|%s|\n", input + end);
-		// printf("|%c|\n", input[end]);
-		// printf("%d\n", end);
 		end++;
-	}
 	if (end <= *i + 1)
 		return (input);
 	key = ft_substr(input, *i + 1, end - *i - 1);
 	if (!key)
+	{
+		free(input);
 		return (NULL);
+	}
 	value = get_variable(shell, key, ft_strlen(key));
 	free(key);
 	if (!value)
+	{
+		free(input);
 		return (NULL);
+	}
 	new_input = replace_segment(input, *i, end, value);
 	if (!new_input)
+	{
+		free(input);
 		return (NULL);
+	}
 	*i += ft_strlen(value);
 	free(value);
+	free(input);
 	return (new_input);
 }
 
@@ -171,7 +176,6 @@ char	*expand_input(t_mini *shell, char *input)
 	{
 		if (input[i] == '"')
 			input = double_quotes_expand(shell, input, &i);
-		// printf("i = %d\n", i);
 		if (input[i] == '\'')
 			i += quote_offset(input + i, input[i]);
 		if (input[i] == '$' && input[i + 1] && input[i + 1] != '$' && input[i + 1] != '/')
@@ -183,8 +187,6 @@ char	*expand_input(t_mini *shell, char *input)
 			else
 			{
 				input = expand_variable(shell, input, &i);
-				// printf("expanded version = %s\n", input);
-				// printf("expanded version = %s\n", input + i);
 				continue ;
 			}
 			if (!input)


### PR DESCRIPTION
<< LIM used to print out minishell: : command not found

Now it's ok, << LIM just gives prompt back after handling heredoc, also doesn't leak on that department.

Modification to ft_free_array (if (!*str)) check might be unnecessary.